### PR TITLE
feat(server): add OpenTelemetry instrumentation with conditional acti…

### DIFF
--- a/doc/English/01-PROJECT_REPORT/03-TESTING/PIT_103_OPENTELEMETRY_WIRING.md
+++ b/doc/English/01-PROJECT_REPORT/03-TESTING/PIT_103_OPENTELEMETRY_WIRING.md
@@ -1,0 +1,95 @@
+# PIT-103 — OpenTelemetry Wiring
+
+> **Date:** 21/07/2025
+> **Status:** ✅ Complete
+> **Ticket:** PIT-103 — [HU-4.5] Connect OpenTelemetry to FastAPI server
+
+---
+
+## 📋 Table of Contents
+
+1. [Objective](#-objective)
+2. [Implementation](#-implementation)
+3. [Configuration](#-configuration)
+4. [Test Results](#-test-results)
+5. [Files Modified](#-files-modified)
+
+---
+
+## 🎯 Objective
+
+Connect OpenTelemetry distributed tracing to the FastAPI backend, providing automatic span generation per HTTP request and a clean shutdown lifecycle. Telemetry is conditionally activated via the `OTEL_ENABLED` environment variable (default: disabled).
+
+---
+
+## 🔧 Implementation
+
+### Module: `src/server/app/core/telemetry.py`
+
+Three public functions:
+
+| Function | Purpose |
+|----------|---------|
+| `setup_telemetry(app)` | Configures TracerProvider + OTLPSpanExporter (gRPC) + FastAPIInstrumentor. No-op when disabled. |
+| `get_tracer(name)` | Returns an OTel tracer for custom spans, or a MagicMock no-op when disabled. |
+| `shutdown_telemetry()` | Flushes pending spans and shuts down TracerProvider gracefully. |
+
+**Design decisions:**
+- **Lazy imports** inside each function to avoid ImportError in test environments where OTel packages are mocked.
+- **Graceful degradation** — ImportError and generic exceptions are caught and logged, never propagated.
+- **No-op pattern** — When `OTEL_ENABLED=False`, all functions return immediately with zero overhead.
+
+### Wiring in `main.py`
+
+```python
+# In lifespan handler:
+setup_telemetry(app)    # Before startup_event()
+yield
+shutdown_telemetry()    # Before shutdown_event()
+```
+
+---
+
+## ⚙️ Configuration
+
+Three new settings in `src/server/app/core/config.py`:
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `OTEL_ENABLED` | `bool` | `False` | Enable/disable telemetry |
+| `OTEL_SERVICE_NAME` | `str` | `"softarchitect-ai"` | Service name in spans |
+| `OTEL_EXPORTER_ENDPOINT` | `str` | `"localhost:4317"` | OTLP gRPC collector endpoint |
+
+To enable in `.env`:
+```env
+OTEL_ENABLED=true
+OTEL_EXPORTER_ENDPOINT=localhost:4317
+```
+
+---
+
+## 🧪 Test Results
+
+**8 unit tests** — all passing:
+
+| Test | Scenario |
+|------|----------|
+| `test_setup_disabled_is_noop` | No-op when OTEL_ENABLED=False |
+| `test_setup_enabled_configures_provider` | TracerProvider + exporter + instrumentor wired |
+| `test_setup_handles_import_error` | ImportError caught gracefully |
+| `test_get_tracer_disabled_returns_mock` | Returns MagicMock when disabled |
+| `test_get_tracer_enabled_returns_real_tracer` | Delegates to opentelemetry.trace |
+| `test_shutdown_disabled_is_noop` | No-op when disabled |
+| `test_shutdown_enabled_calls_provider_shutdown` | Calls provider.shutdown() |
+| `test_shutdown_handles_exception` | RuntimeError caught gracefully |
+
+---
+
+## 📁 Files Modified
+
+| File | Change |
+|------|--------|
+| `src/server/app/core/telemetry.py` | **New** — OTel setup, tracer, shutdown |
+| `src/server/app/core/config.py` | Added 3 OTEL_* settings |
+| `src/server/app/main.py` | Wired setup_telemetry/shutdown_telemetry in lifespan |
+| `tests/server/unit/app/core/test_telemetry.py` | **New** — 8 unit tests |

--- a/doc/Español/01-PROJECT_REPORT/03-TESTING/PIT_103_OPENTELEMETRY_WIRING.md
+++ b/doc/Español/01-PROJECT_REPORT/03-TESTING/PIT_103_OPENTELEMETRY_WIRING.md
@@ -1,0 +1,95 @@
+# PIT-103 — Cableado OpenTelemetry
+
+> **Fecha:** 21/07/2025
+> **Estado:** ✅ Completado
+> **Ticket:** PIT-103 — [HU-4.5] Conectar OpenTelemetry al servidor FastAPI
+
+---
+
+## 📖 Tabla de Contenidos
+
+1. [Objetivo](#-objetivo)
+2. [Implementación](#-implementación)
+3. [Configuración](#-configuración)
+4. [Resultados de Tests](#-resultados-de-tests)
+5. [Archivos Modificados](#-archivos-modificados)
+
+---
+
+## 🎯 Objetivo
+
+Conectar el trazado distribuido de OpenTelemetry al backend FastAPI, proporcionando generación automática de spans por petición HTTP y un ciclo de vida de apagado limpio. La telemetría se activa condicionalmente mediante la variable de entorno `OTEL_ENABLED` (por defecto: deshabilitado).
+
+---
+
+## 🔧 Implementación
+
+### Módulo: `src/server/app/core/telemetry.py`
+
+Tres funciones públicas:
+
+| Función | Propósito |
+|---------|-----------|
+| `setup_telemetry(app)` | Configura TracerProvider + OTLPSpanExporter (gRPC) + FastAPIInstrumentor. No-op cuando está deshabilitado. |
+| `get_tracer(name)` | Devuelve un tracer OTel para spans personalizados, o un MagicMock no-op cuando está deshabilitado. |
+| `shutdown_telemetry()` | Vacía spans pendientes y apaga el TracerProvider de forma ordenada. |
+
+**Decisiones de diseño:**
+- **Imports lazy** dentro de cada función para evitar ImportError en entornos de test donde los paquetes OTel están mockeados.
+- **Degradación elegante** — ImportError y excepciones genéricas se capturan y loguean, nunca se propagan.
+- **Patrón no-op** — Cuando `OTEL_ENABLED=False`, todas las funciones retornan inmediatamente sin overhead.
+
+### Cableado en `main.py`
+
+```python
+# En el handler lifespan:
+setup_telemetry(app)    # Antes de startup_event()
+yield
+shutdown_telemetry()    # Antes de shutdown_event()
+```
+
+---
+
+## ⚙️ Configuración
+
+Tres nuevos settings en `src/server/app/core/config.py`:
+
+| Variable | Tipo | Default | Descripción |
+|----------|------|---------|-------------|
+| `OTEL_ENABLED` | `bool` | `False` | Habilitar/deshabilitar telemetría |
+| `OTEL_SERVICE_NAME` | `str` | `"softarchitect-ai"` | Nombre del servicio en spans |
+| `OTEL_EXPORTER_ENDPOINT` | `str` | `"localhost:4317"` | Endpoint del colector OTLP gRPC |
+
+Para habilitar en `.env`:
+```env
+OTEL_ENABLED=true
+OTEL_EXPORTER_ENDPOINT=localhost:4317
+```
+
+---
+
+## 🧪 Resultados de Tests
+
+**8 unit tests** — todos pasando:
+
+| Test | Escenario |
+|------|-----------|
+| `test_setup_disabled_is_noop` | No-op cuando OTEL_ENABLED=False |
+| `test_setup_enabled_configures_provider` | TracerProvider + exporter + instrumentor cableados |
+| `test_setup_handles_import_error` | ImportError capturado elegantemente |
+| `test_get_tracer_disabled_returns_mock` | Retorna MagicMock cuando deshabilitado |
+| `test_get_tracer_enabled_returns_real_tracer` | Delega a opentelemetry.trace |
+| `test_shutdown_disabled_is_noop` | No-op cuando deshabilitado |
+| `test_shutdown_enabled_calls_provider_shutdown` | Llama provider.shutdown() |
+| `test_shutdown_handles_exception` | RuntimeError capturado elegantemente |
+
+---
+
+## 📁 Archivos Modificados
+
+| Archivo | Cambio |
+|---------|--------|
+| `src/server/app/core/telemetry.py` | **Nuevo** — Setup OTel, tracer, shutdown |
+| `src/server/app/core/config.py` | Añadidos 3 settings OTEL_* |
+| `src/server/app/main.py` | Cableado setup_telemetry/shutdown_telemetry en lifespan |
+| `tests/server/unit/app/core/test_telemetry.py` | **Nuevo** — 8 unit tests |

--- a/src/server/app/core/config.py
+++ b/src/server/app/core/config.py
@@ -79,6 +79,11 @@ class Settings(BaseSettings):
     CHAT_MAX_HISTORY_MESSAGES: int = 100  # Max messages (50 user + 50 assistant)
     CHAT_MAX_MESSAGE_LENGTH: int = 20000  # Max chars per message (model supports 32K)
 
+    # OpenTelemetry Configuration
+    OTEL_ENABLED: bool = False
+    OTEL_SERVICE_NAME: str = "softarchitect-ai"
+    OTEL_EXPORTER_ENDPOINT: str = "localhost:4317"
+
     # Streaming Configuration
     WS_HEARTBEAT_INTERVAL_SECONDS: float = 30.0
     WS_IDLE_TIMEOUT_SECONDS: float = 300.0

--- a/src/server/app/core/telemetry.py
+++ b/src/server/app/core/telemetry.py
@@ -1,0 +1,113 @@
+"""
+OpenTelemetry instrumentation for SoftArchitect AI backend.
+
+Provides distributed tracing via TracerProvider, automatic FastAPI span
+generation, and conditional activation via OTEL_ENABLED environment variable.
+
+Usage:
+    Called once during application startup in main.py lifespan handler.
+    When OTEL_ENABLED=false (default), this module is a no-op.
+
+Configuration (.env):
+    OTEL_ENABLED: bool — Enable/disable telemetry (default: false)
+    OTEL_SERVICE_NAME: str — Service name for spans (default: "softarchitect-ai")
+    OTEL_EXPORTER_ENDPOINT: str — OTLP gRPC endpoint (default: "localhost:4317")
+"""
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def setup_telemetry(app: Any) -> None:
+    """Configure and start OpenTelemetry instrumentation.
+
+    Sets up TracerProvider with OTLPSpanExporter and instruments
+    the FastAPI application for automatic span generation per request.
+
+    This function is a no-op when OTEL_ENABLED is False.
+
+    Args:
+        app: The FastAPI application instance to instrument.
+    """
+    from app.core.config import settings
+
+    if not settings.OTEL_ENABLED:
+        logger.info("OpenTelemetry disabled (OTEL_ENABLED=false)")
+        return
+
+    try:
+        from opentelemetry import trace
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+            OTLPSpanExporter,
+        )
+        from opentelemetry.instrumentation.fastapi import (  # type: ignore[import-untyped]
+            FastAPIInstrumentor,
+        )
+        from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+        resource = Resource(attributes={SERVICE_NAME: settings.OTEL_SERVICE_NAME})
+
+        provider = TracerProvider(resource=resource)
+        exporter = OTLPSpanExporter(
+            endpoint=settings.OTEL_EXPORTER_ENDPOINT,
+            insecure=True,  # Local collector, no TLS needed
+        )
+        provider.add_span_processor(BatchSpanProcessor(exporter))
+        trace.set_tracer_provider(provider)
+
+        FastAPIInstrumentor.instrument_app(app)
+
+        logger.info(
+            "OpenTelemetry enabled: service=%s, endpoint=%s",
+            settings.OTEL_SERVICE_NAME,
+            settings.OTEL_EXPORTER_ENDPOINT,
+        )
+    except ImportError as e:
+        logger.warning("OpenTelemetry packages not available: %s", e)
+    except Exception as e:
+        logger.error("Failed to initialize OpenTelemetry: %s", e)
+
+
+def get_tracer(name: str) -> Any:
+    """Get a tracer instance for creating custom spans.
+
+    Args:
+        name: Tracer name, typically the module name.
+
+    Returns:
+        A tracer from the global TracerProvider, or a no-op tracer
+        if OpenTelemetry is not enabled.
+    """
+    from app.core.config import settings
+
+    if not settings.OTEL_ENABLED:
+        from unittest.mock import MagicMock
+
+        return MagicMock()
+
+    from opentelemetry import trace
+
+    return trace.get_tracer(name)
+
+
+def shutdown_telemetry() -> None:
+    """Flush and shut down the TracerProvider gracefully."""
+    from app.core.config import settings
+
+    if not settings.OTEL_ENABLED:
+        return
+
+    try:
+        from opentelemetry import trace
+        from opentelemetry.sdk.trace import TracerProvider as SdkTracerProvider
+
+        provider = trace.get_tracer_provider()
+        if isinstance(provider, SdkTracerProvider):
+            provider.shutdown()  # type: ignore[no-untyped-call]
+            logger.info("OpenTelemetry shut down gracefully")
+    except Exception as e:
+        logger.warning("Error shutting down OpenTelemetry: %s", e)

--- a/src/server/app/main.py
+++ b/src/server/app/main.py
@@ -35,6 +35,7 @@ from starlette.middleware.gzip import GZipMiddleware
 from app.api.v1 import router as api_v1_router
 from app.core.config import settings
 from app.core.database import init_chromadb, init_sqlite
+from app.core.telemetry import setup_telemetry, shutdown_telemetry
 
 # ═══════════════════════════════════════════════════════════════
 # Logging Setup
@@ -103,8 +104,10 @@ async def lifespan(app: FastAPI):
     as the deprecated @app.on_event decorators using the modern
     FastAPI lifespan API.
     """
+    setup_telemetry(app)
     await startup_event()
     yield  # Application runs here
+    shutdown_telemetry()
     await shutdown_event()
 
 

--- a/tests/server/unit/app/core/test_telemetry.py
+++ b/tests/server/unit/app/core/test_telemetry.py
@@ -1,0 +1,205 @@
+"""
+Unit tests for OpenTelemetry instrumentation module (app.core.telemetry).
+
+Tests cover:
+- No-op behavior when OTEL_ENABLED=False (default)
+- TracerProvider + FastAPIInstrumentor wiring when enabled
+- get_tracer() returns MagicMock when disabled
+- Graceful shutdown behavior
+- ImportError / generic exception resilience
+"""
+
+from unittest.mock import MagicMock, patch
+
+SETTINGS_PATH = "app.core.config.settings"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _settings_mock(otel_enabled: bool = False) -> MagicMock:
+    """Return a Settings mock with OTEL_* fields."""
+    s = MagicMock()
+    s.OTEL_ENABLED = otel_enabled
+    s.OTEL_SERVICE_NAME = "test-service"
+    s.OTEL_EXPORTER_ENDPOINT = "localhost:4317"
+    return s
+
+
+# ---------------------------------------------------------------------------
+# setup_telemetry
+# ---------------------------------------------------------------------------
+
+
+class TestSetupTelemetry:
+    """Tests for setup_telemetry()."""
+
+    def test_setup_disabled_is_noop(self) -> None:
+        """When OTEL_ENABLED=False, setup_telemetry does nothing."""
+        from app.core.telemetry import setup_telemetry
+
+        with patch(SETTINGS_PATH, _settings_mock(False)):
+            app = MagicMock()
+            setup_telemetry(app)
+
+    def test_setup_enabled_configures_provider(self) -> None:
+        """When OTEL_ENABLED=True, TracerProvider and instrumentor are wired."""
+        mock_trace = MagicMock()
+        mock_provider_cls = MagicMock()
+        mock_provider_instance = MagicMock()
+        mock_provider_cls.return_value = mock_provider_instance
+        mock_exporter_cls = MagicMock()
+        mock_processor_cls = MagicMock()
+        mock_resource_cls = MagicMock()
+        mock_service_name = "SERVICE_NAME"
+        mock_instrumentor = MagicMock()
+
+        modules = {
+            "opentelemetry": MagicMock(trace=mock_trace),
+            "opentelemetry.trace": mock_trace,
+            "opentelemetry.sdk.trace": MagicMock(TracerProvider=mock_provider_cls),
+            "opentelemetry.sdk.trace.export": MagicMock(
+                BatchSpanProcessor=mock_processor_cls
+            ),
+            "opentelemetry.sdk.resources": MagicMock(
+                SERVICE_NAME=mock_service_name, Resource=mock_resource_cls
+            ),
+            "opentelemetry.exporter.otlp.proto.grpc.trace_exporter": MagicMock(
+                OTLPSpanExporter=mock_exporter_cls
+            ),
+            "opentelemetry.instrumentation.fastapi": MagicMock(
+                FastAPIInstrumentor=mock_instrumentor
+            ),
+        }
+
+        with (
+            patch(SETTINGS_PATH, _settings_mock(True)),
+            patch.dict("sys.modules", modules),
+        ):
+            from app.core.telemetry import setup_telemetry
+
+            app = MagicMock()
+            setup_telemetry(app)
+
+            mock_resource_cls.assert_called_once()
+            mock_provider_cls.assert_called_once()
+            mock_exporter_cls.assert_called_once_with(
+                endpoint="localhost:4317", insecure=True
+            )
+            mock_trace.set_tracer_provider.assert_called_once_with(
+                mock_provider_instance
+            )
+            mock_instrumentor.instrument_app.assert_called_once_with(app)
+
+    def test_setup_handles_import_error(self) -> None:
+        """ImportError is caught gracefully when OTel packages are missing."""
+        from app.core.telemetry import setup_telemetry
+
+        with (
+            patch(SETTINGS_PATH, _settings_mock(True)),
+            patch.dict("sys.modules", {"opentelemetry": None}),
+        ):
+            app = MagicMock()
+            # Should NOT raise — caught internally
+            setup_telemetry(app)
+
+
+# ---------------------------------------------------------------------------
+# get_tracer
+# ---------------------------------------------------------------------------
+
+
+class TestGetTracer:
+    """Tests for get_tracer()."""
+
+    def test_get_tracer_disabled_returns_mock(self) -> None:
+        """When disabled, get_tracer returns a MagicMock no-op."""
+        from app.core.telemetry import get_tracer
+
+        with patch(SETTINGS_PATH, _settings_mock(False)):
+            tracer = get_tracer("my_module")
+            assert isinstance(tracer, MagicMock)
+
+    def test_get_tracer_enabled_returns_real_tracer(self) -> None:
+        """When enabled, get_tracer delegates to opentelemetry.trace.get_tracer."""
+        mock_trace = MagicMock()
+        expected_tracer = MagicMock()
+        mock_trace.get_tracer.return_value = expected_tracer
+
+        with (
+            patch(SETTINGS_PATH, _settings_mock(True)),
+            patch.dict(
+                "sys.modules",
+                {
+                    "opentelemetry": MagicMock(trace=mock_trace),
+                    "opentelemetry.trace": mock_trace,
+                },
+            ),
+        ):
+            from app.core.telemetry import get_tracer
+
+            tracer = get_tracer("my_module")
+            mock_trace.get_tracer.assert_called_once_with("my_module")
+            assert tracer is expected_tracer
+
+
+# ---------------------------------------------------------------------------
+# shutdown_telemetry
+# ---------------------------------------------------------------------------
+
+
+class TestShutdownTelemetry:
+    """Tests for shutdown_telemetry()."""
+
+    def test_shutdown_disabled_is_noop(self) -> None:
+        """When disabled, shutdown does nothing."""
+        from app.core.telemetry import shutdown_telemetry
+
+        with patch(SETTINGS_PATH, _settings_mock(False)):
+            shutdown_telemetry()
+
+    def test_shutdown_enabled_calls_provider_shutdown(self) -> None:
+        """When enabled, shutdown calls provider.shutdown()."""
+        mock_trace = MagicMock()
+        mock_provider = MagicMock()
+        mock_provider.shutdown = MagicMock()
+        mock_trace.get_tracer_provider.return_value = mock_provider
+
+        with (
+            patch(SETTINGS_PATH, _settings_mock(True)),
+            patch.dict(
+                "sys.modules",
+                {
+                    "opentelemetry": MagicMock(trace=mock_trace),
+                    "opentelemetry.trace": mock_trace,
+                    "opentelemetry.sdk": MagicMock(),
+                    "opentelemetry.sdk.trace": MagicMock(TracerProvider=MagicMock),
+                },
+            ),
+        ):
+            from app.core.telemetry import shutdown_telemetry
+
+            shutdown_telemetry()
+            mock_provider.shutdown.assert_called_once()
+
+    def test_shutdown_handles_exception(self) -> None:
+        """Exception during shutdown is caught gracefully."""
+        mock_trace = MagicMock()
+        mock_trace.get_tracer_provider.side_effect = RuntimeError("boom")
+
+        with (
+            patch(SETTINGS_PATH, _settings_mock(True)),
+            patch.dict(
+                "sys.modules",
+                {
+                    "opentelemetry": MagicMock(trace=mock_trace),
+                    "opentelemetry.trace": mock_trace,
+                },
+            ),
+        ):
+            from app.core.telemetry import shutdown_telemetry
+
+            # Should NOT raise
+            shutdown_telemetry()


### PR DESCRIPTION
**PR description:**

> ## feat(server): add OpenTelemetry instrumentation with conditional activation
> 
> **PIT-103** — [HU-4.5] Conectar OpenTelemetry al servidor FastAPI
> 
> ### Changes
> - New telemetry.py: TracerProvider + OTLPSpanExporter + FastAPIInstrumentor
> - New settings: `OTEL_ENABLED` (default: false), `OTEL_SERVICE_NAME`, `OTEL_EXPORTER_ENDPOINT`
> - Wired `setup_telemetry()`/`shutdown_telemetry()` in main.py lifespan handler
> - **Zero overhead when disabled** — no OTel imports or providers created
> 
> ### Testing
> - 8 unit tests (test_telemetry.py)
> - Covers: enabled/disabled paths, ImportError handling, graceful shutdown, get_tracer mock fallback
> 
> ### Documentation
> - Bilingual report: `doc/{English,Español}/01-PROJECT_REPORT/03-TESTING/PIT_103_OPENTELEMETRY_WIRING.md`